### PR TITLE
Fixes #26: pydevd_pycharm snake case update

### DIFF
--- a/plugin_src/PyCharmDebug/Content/Python/pycharmdebug/actions/connect.py
+++ b/plugin_src/PyCharmDebug/Content/Python/pycharmdebug/actions/connect.py
@@ -47,11 +47,18 @@ class PyCharmDebugConnect(unreal.ToolMenuEntryScript):
         except ImportError:
             unreal.log_error("Failed to import pydevd_pycharm")
             return
-
-        pydevd_pycharm.settrace(
-            HOST,
-            port=get_debug_port(),
-            stdoutToServer=True,
-            stderrToServer=True,
-        )
+        try:
+            pydevd_pycharm.settrace(
+                HOST,
+                port=get_debug_port(),
+                stdoutToServer=True,
+                stderrToServer=True,
+            )
+        except TypeError:  # new versions of pydevd_pycharm moved to snake case
+            pydevd_pycharm.settrace(
+                HOST,
+                port=get_debug_port(),
+                stdout_to_server=True,
+                stderr_to_server=True,
+            )
         unreal.log("Connected to PyCharm debugger")


### PR DESCRIPTION
pydevd_pycharm api appears to have moved from camel case to snake case, see: https://youtrack.jetbrains.com/issue/PY-83096/pydevdpycharm.settrace-not-recognizing-parameters-stdoutToServer-and-stderrToServer